### PR TITLE
Automatically run the tests on a CI server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+
+go:
+  - 1.1
+  - tip
+
+script:
+  - go get github.com/customerio/gospec
+  - go test -v
+
+services:
+  - redis-server

--- a/all_specs_test.go
+++ b/all_specs_test.go
@@ -16,9 +16,9 @@ func TestAllSpecs(t *testing.T) {
 
 	r.Parallel = false
 
-	// Load test instance of redis on port 6400
+	// Load test instance of redis on port 6379
 	Configure(map[string]string{
-		"server":  "localhost:6400",
+		"server":  "localhost:6379",
 		"process": "1",
 		"pool":    "1",
 	})

--- a/config_test.go
+++ b/config_test.go
@@ -22,7 +22,7 @@ func ConfigSpec(c gospec.Context) {
 		c.Expect(Config.pool.MaxIdle, Equals, 1)
 
 		Configure(map[string]string{
-			"server":  "localhost:6400",
+			"server":  "localhost:6379",
 			"process": "1",
 			"pool":    "20",
 		})
@@ -34,7 +34,7 @@ func ConfigSpec(c gospec.Context) {
 		c.Expect(Config.processId, Equals, "1")
 
 		Configure(map[string]string{
-			"server":  "localhost:6400",
+			"server":  "localhost:6379",
 			"process": "2",
 		})
 
@@ -51,7 +51,7 @@ func ConfigSpec(c gospec.Context) {
 
 	c.Specify("requires a process parameter", func() {
 		err := recoverOnPanic(func() {
-			Configure(map[string]string{"server": "localhost:6400"})
+			Configure(map[string]string{"server": "localhost:6379"})
 		})
 
 		c.Expect(err, Equals, "Configure requires a 'process' option, which uniquely identifies this instance")


### PR DESCRIPTION
This adds travis-ci to get the tests running automatically.

I've changed the default port in the tests to the default redis one (6379 instead of 6400), as it's the port redis is running on at travis.
Maybe this could be overwritten with an optional environment variable?

I also had to manually get gospec.
As it's not required in any source file other than the specs, it's not fetched automatically with go get.

[here's a passing build](https://travis-ci.org/dmathieu/go-workers/builds/9724748).

After merging this, you'll need to actually [activate the travis hook](http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in) on the master repository.
