### PR TITLE
Don't consider an empty queue as an error

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -46,7 +46,10 @@ func (f *fetch) Fetch() {
 			message, err := redis.String(conn.Do("brpoplpush", f.manager.queue, f.inprogressQueue(), 1))
 
 			if err != nil {
-				Logger.Println("ERR: ", err)
+				// If redis returns null, the queue is empty. Just ignore the error.
+				if err != fmt.Errorf("redigo: nil returned") {
+					Logger.Println("ERR: ", err)
+				}
 			} else {
 				c <- message
 			}


### PR DESCRIPTION
When running the worker, for any empty queue, we will get `redigo: nil returned`.

This is because `BRPOPLPUSH` returns `null` when the queue is empty.
[There is an issue about that](https://code.google.com/p/redis/issues/detail?id=650).

This patch ignores this error, so we don't get the false impression to have an error in the worker when that is not the case.

**Note:** I wanted to write a test for this, but it would seem gospec doesn't support mocking, and didn't want to end up adding a new dependency for such a small fix.
