### PR TITLE
Expose redis connection

### DIFF
--- a/config.go
+++ b/config.go
@@ -53,3 +53,7 @@ func Configure(options map[string]string) {
 		},
 	}
 }
+
+func (c *config) GetConn() redis.Conn {
+	return c.pool.Get()
+}


### PR DESCRIPTION
This exposes the redis connection so that it can be used in middleware, for example a middleware that replies back to sidekiq that a message has been completed:

```
conn := workers.Config.GetConn()
```
