### PR TITLE
Don't open so many connections to redis

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -35,13 +35,13 @@ func (f *fetch) Fetch() {
 	f.processOldMessages()
 
 	go (func(c chan string) {
+		conn := Config.Pool.Get()
+		defer conn.Close()
+
 		for {
 			if f.Closed() {
 				break
 			}
-
-			conn := Config.Pool.Get()
-			defer conn.Close()
 
 			message, err := redis.String(conn.Do("brpoplpush", f.manager.queue, f.inprogressQueue(), 1))
 

--- a/scheduled.go
+++ b/scheduled.go
@@ -30,7 +30,6 @@ func (s *scheduled) poll(continuing bool) {
 	}
 
 	conn := Config.Pool.Get()
-	defer conn.Close()
 
 	now := time.Now().Unix()
 
@@ -51,6 +50,7 @@ func (s *scheduled) poll(continuing bool) {
 		}
 	}
 
+	conn.Close()
 	if continuing {
 		time.Sleep(POLL_INTERVAL * time.Second)
 		s.poll(true)


### PR DESCRIPTION
Hi,

I'm trying to use go-workers, but I have some issues. One of them is that go-workers open so many connections to redis that it fails (lookup localhost: too many open files). I think it's because `defer` is not used correctly.

The `defer` statement is executed when the surrounding function returns. In `fetcher.go`, it opens a new connection at each iteration in the `for` loop, but the `Close` are defered until the fetch is closed and the surrounding function returns.

In `scheduled.go`, the `defer` is never called, except with a panic, because the surrouding function calls itself and so never returns.

I'm not sure if my patch is correct, but it's better than now. What do you think?
