### PR TITLE
Let users enqueue jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Example usage:
       // pull messages from "myqueue2" with concurrency of 20
       workers.Process("myqueue2", myJob, 20)
 
+      // Add a job to a queue
+      workers.Enqueue("myqueue3", "Add", []int{1, 2})
+
       // stats will be available at http://localhost:8080/stats
       go workers.StatsServer(8080)
 

--- a/all_specs_test.go
+++ b/all_specs_test.go
@@ -36,6 +36,7 @@ func TestAllSpecs(t *testing.T) {
 	r.AddSpec(WorkerSpec)
 	r.AddSpec(ManagerSpec)
 	r.AddSpec(ScheduledSpec)
+	r.AddSpec(EnqueueSpec)
 	r.AddSpec(MiddlewareSpec)
 	r.AddSpec(MiddlewareRetrySpec)
 	r.AddSpec(MiddlewareStatsSpec)

--- a/enqueue.go
+++ b/enqueue.go
@@ -1,0 +1,28 @@
+package workers
+
+import (
+	"encoding/json"
+)
+
+type EnqueueData struct {
+	Class string `json:"class"`
+	Args  interface{} `json:"args"`
+}
+
+func Enqueue(queue, class string, args interface{}) error {
+	conn := Config.Pool.Get()
+	defer conn.Close()
+
+	bytes, err := json.Marshal(EnqueueData{class, args})
+	if err != nil {
+		return err
+	}
+
+	_, err = conn.Do("sadd", Config.namespace+"queues", queue)
+	if err != nil {
+		return err
+	}
+	queue = Config.namespace + "queue:" + queue
+	_, err = conn.Do("rpush", queue, bytes)
+	return err
+}

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -1,0 +1,51 @@
+package workers
+
+import (
+	"encoding/json"
+	"github.com/customerio/gospec"
+	. "github.com/customerio/gospec"
+	"github.com/garyburd/redigo/redis"
+)
+
+func EnqueueSpec(c gospec.Context) {
+	was := Config.namespace
+	Config.namespace = "prod:"
+
+	c.Specify("Enqueue", func() {
+		conn := Config.Pool.Get()
+		defer conn.Close()
+
+		c.Specify("makes the queue available", func() {
+			Enqueue("enqueue1", "Add", []int{1, 2})
+
+			found, _ := redis.Bool(conn.Do("sismember", "prod:queues", "enqueue1"))
+			c.Expect(found, IsTrue)
+		})
+
+		c.Specify("adds a job to the queue", func() {
+			nb, _ := redis.Int(conn.Do("llen", "prod:queue:enqueue2"))
+			c.Expect(nb, Equals, 0)
+
+			Enqueue("enqueue2", "Add", []int{1, 2})
+
+			nb, _ = redis.Int(conn.Do("llen", "prod:queue:enqueue2"))
+			c.Expect(nb, Equals, 1)
+		})
+
+		c.Specify("saves the arguments", func() {
+			Enqueue("enqueue3", "Compare", []string{"foo", "bar"})
+
+			bytes, _ := redis.Bytes(conn.Do("lpop", "prod:queue:enqueue3"))
+			var result map[string]interface{}
+			json.Unmarshal(bytes, &result)
+			c.Expect(result["class"], Equals, "Compare")
+
+			args := result["args"].([]interface{})
+			c.Expect(len(args), Equals, 2)
+			c.Expect(args[0], Equals, "foo")
+			c.Expect(args[1], Equals, "bar")
+		})
+	})
+
+	Config.namespace = was
+}


### PR DESCRIPTION
I find useful to be able to enqueue jobs as well as performing them. So, I've added this feature to go-workers.

Please note that I use `Config.namespace`, so it should be merged only after #10.
