### PR TITLE
Don't try to reconnect to redis more than one time per second

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -2,6 +2,8 @@ package workers
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/garyburd/redigo/redis"
 )
 
@@ -49,6 +51,7 @@ func (f *fetch) Fetch() {
 				// If redis returns null, the queue is empty. Just ignore the error.
 				if err.Error() != "redigo: nil returned" {
 					Logger.Println("ERR: ", err)
+					time.Sleep(1 * time.Second)
 				}
 			} else {
 				c <- message


### PR DESCRIPTION
When redis is down, go-workers loops and can fill a lot of logs very fast. I've added a pause between two retries.
