### PR TITLE
Trim namespace when moving from scheduled zset to queued list

### DIFF
--- a/scheduled.go
+++ b/scheduled.go
@@ -1,8 +1,10 @@
 package workers
 
 import (
-	"github.com/garyburd/redigo/redis"
+	"strings"
 	"time"
+
+	"github.com/garyburd/redigo/redis"
 )
 
 const (
@@ -45,6 +47,7 @@ func (s *scheduled) poll(continuing bool) {
 
 			if removed, _ := redis.Bool(conn.Do("zrem", key, messages[0])); removed {
 				queue, _ := message.Get("queue").String()
+				queue = strings.TrimPrefix(queue, Config.namespace)
 				conn.Do("lpush", Config.namespace+"queue:"+queue, message.ToJson())
 			}
 		}


### PR DESCRIPTION
Fixes bug where retry scheduler pushes the retries on the wrong queue.

E.g.: if the namespace was set to “resque:”, descheduling would push the job onto resque:queue:resque:foobar
