### PR TITLE
Allowing for a custom logger to be assigned to workers.Logger

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -12,7 +12,7 @@ const (
 	SCHEDULED_JOBS_KEY = "schedule"
 )
 
-var Logger = log.New(os.Stdout, "workers: ", log.Ldate|log.Lmicroseconds)
+var Logger WorkersLogger = log.New(os.Stdout, "workers: ", log.Ldate|log.Lmicroseconds)
 
 var managers = make(map[string]*manager)
 var schedule = newScheduled(RETRY_KEY, SCHEDULED_JOBS_KEY)

--- a/workers_logger.go
+++ b/workers_logger.go
@@ -1,0 +1,6 @@
+package workers
+
+type WorkersLogger interface {
+	Println(...interface{})
+	Printf(string, ...interface{})
+}


### PR DESCRIPTION
specifically so that I can use my existing [`logrus.Logger`](https://godoc.org/github.com/Sirupsen/logrus#Logger) and ensure all of my log output is consistently formatted.
