### PR TITLE
Coerce error message to string when setting on message

### DIFF
--- a/middleware_retry.go
+++ b/middleware_retry.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"time"
@@ -21,7 +22,7 @@ func (r *MiddlewareRetry) Call(queue string, message *Msg, next func() bool) (ac
 
 			if retry(message) {
 				message.Set("queue", queue)
-				message.Set("error_message", e)
+				message.Set("error_message", fmt.Sprintf("%v", e))
 				retryCount := incrementRetry(message)
 
 				_, err := conn.Do(


### PR DESCRIPTION
so that non-string/non-error things returned by recover are handled as well.  Without this, the `ToJson` call below explodes (sometimes).
