### PR TITLE
added custom per-manager middleware chains

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -51,7 +51,7 @@ func (w *worker) process(message *Msg) (acknowledge bool) {
 		recover()
 	}()
 
-	return Middleware.call(w.manager.queueName(), message, func() {
+	return w.manager.mids.call(w.manager.queueName(), message, func() {
 		w.manager.job(message)
 	})
 }

--- a/workers.go
+++ b/workers.go
@@ -24,8 +24,8 @@ var Middleware = NewMiddleware(
 	&MiddlewareStats{},
 )
 
-func Process(queue string, job jobFunc, concurrency int) {
-	managers[queue] = newManager(queue, job, concurrency)
+func Process(queue string, job jobFunc, concurrency int, mids ...Action) {
+	managers[queue] = newManager(queue, job, concurrency, mids...)
 }
 
 func Run() {


### PR DESCRIPTION
Hello John!
Please consider adding this simple per-manager custom middleware chain feature. There are no changes to base API, but when calling worker.Process with extra arguments of type *Action, separate middleware chains are configured for managers in question. I.e.:

```go
workers.Process("myqueue1", myJob1, 10) // process with default worker.Middleware chain;
workers.Process("myqueue2", myJob2, 10, &customMid{}, &customMid2{}) // process with custom middlewares appended to default chain. 
```
Default middlewares are copied into custom chain and then all extra middlewares are appended to it. Managers without custom chains share one global workers.Middleware.
I think that this mechanism is useful for creating separate queues with and without retries,  etc.