### PR TITLE
Enqueue* funcs now return queue size

### DIFF
--- a/all_specs_test.go
+++ b/all_specs_test.go
@@ -1,8 +1,9 @@
 package workers
 
 import (
-	"github.com/customerio/gospec"
 	"testing"
+
+	"github.com/customerio/gospec"
 )
 
 // You will need to list every spec in a TestXxx method like this,
@@ -38,6 +39,7 @@ func TestAllSpecs(t *testing.T) {
 	r.AddSpec(ManagerSpec)
 	r.AddSpec(ScheduledSpec)
 	r.AddSpec(EnqueueSpec)
+	r.AddSpec(QueueSpec)
 	r.AddSpec(MiddlewareSpec)
 	r.AddSpec(MiddlewareRetrySpec)
 	r.AddSpec(MiddlewareStatsSpec)

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -86,6 +86,18 @@ func EnqueueSpec(c gospec.Context) {
 			retryCount := int(result["retry_count"].(float64))
 			c.Expect(retryCount, Equals, 13)
 		})
+
+		c.Specify("returns queueSize", func() {
+			_, queueSize, _ := Enqueue("enqueue7", "Compare", []string{"foo", "bar"})
+			c.Expect(queueSize, Equals, 1)
+		})
+
+		c.Specify("returns queueSize with the actual size of the queue", func() {
+			for i := 1; i <= 10; i++ {
+				_, queueSize, _ := Enqueue("enqueue8", "Compare", []string{"foo", "bar"})
+				c.Expect(queueSize, Equals, i)
+			}
+		})
 	})
 
 	c.Specify("EnqueueIn", func() {
@@ -94,7 +106,7 @@ func EnqueueSpec(c gospec.Context) {
 		defer conn.Close()
 
 		c.Specify("has added a job in the scheduled queue", func() {
-			_, err := EnqueueIn("enqueuein1", "Compare", 10, map[string]interface{}{"foo": "bar"})
+			_, _, err := EnqueueIn("enqueuein1", "Compare", 10, map[string]interface{}{"foo": "bar"})
 			c.Expect(err, Equals, nil)
 
 			scheduledCount, _ := redis.Int(conn.Do("zcard", scheduleQueue))
@@ -104,7 +116,7 @@ func EnqueueSpec(c gospec.Context) {
 		})
 
 		c.Specify("has the correct 'queue'", func() {
-			_, err := EnqueueIn("enqueuein2", "Compare", 10, map[string]interface{}{"foo": "bar"})
+			_, _, err := EnqueueIn("enqueuein2", "Compare", 10, map[string]interface{}{"foo": "bar"})
 			c.Expect(err, Equals, nil)
 
 			var data EnqueueData
@@ -115,6 +127,13 @@ func EnqueueSpec(c gospec.Context) {
 			c.Expect(data.Queue, Equals, "enqueuein2")
 
 			conn.Do("del", scheduleQueue)
+		})
+
+		c.Specify("returns the number of scheduled jobs", func() {
+			for i := 1; i <= 10; i++ {
+				_, scheduledJobQueueSize, _ := EnqueueIn("enqueuein3", "Compare", 10, []string{"foo", "bar"})
+				c.Expect(scheduledJobQueueSize, Equals, i)
+			}
 		})
 	})
 

--- a/manager.go
+++ b/manager.go
@@ -93,7 +93,7 @@ func newManager(queue string, job jobFunc, concurrency int, mids ...Action) *man
 		}
 	}
 	m := &manager{
-		Config.Namespace + "queue:" + queue,
+		queueKey(queue),
 		nil,
 		job,
 		concurrency,

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,25 @@
+package workers
+
+import "github.com/garyburd/redigo/redis"
+
+func queueKey(simpleName string) string {
+	return Config.Namespace + "queue:" + simpleName
+}
+
+func scheduledQueueKey() string {
+	return Config.Namespace + SCHEDULED_JOBS_KEY
+}
+
+// QueueSize returns the current size of the queue with the given name.
+func QueueSize(queue string) (int, error) {
+	conn := Config.Pool.Get()
+	defer conn.Close()
+	return redis.Int(conn.Do("llen", queueKey(queue)))
+}
+
+// ScheduledQueueSize returns the number of jobs in the scheduled jobs queue.
+func ScheduledQueueSize() (int, error) {
+	conn := Config.Pool.Get()
+	defer conn.Close()
+	return redis.Int(conn.Do("zcard", scheduledQueueKey()))
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,0 +1,35 @@
+package workers
+
+import (
+	"github.com/customerio/gospec"
+	. "github.com/customerio/gospec"
+)
+
+func QueueSpec(c gospec.Context) {
+	was := Config.Namespace
+	Config.Namespace = "prod:"
+
+	c.Specify("QueueSize", func() {
+		c.Specify("returns the actual size of the queue", func() {
+			for i := 1; i <= 10; i++ {
+				Enqueue("queue1", "Compare", []string{"foo", "bar"})
+				queueSize, err := QueueSize("queue1")
+				c.Expect(err, Equals, nil)
+				c.Expect(queueSize, Equals, i)
+			}
+		})
+	})
+
+	c.Specify("ScheduledQueueSize", func() {
+		c.Specify("returns the number of scheduled jobs", func() {
+			for i := 1; i <= 10; i++ {
+				EnqueueIn("queue2", "Compare", 10, []string{"foo", "bar"})
+				queueSize, err := ScheduledQueueSize()
+				c.Expect(err, Equals, nil)
+				c.Expect(queueSize, Equals, i)
+			}
+		})
+	})
+
+	Config.Namespace = was
+}

--- a/scheduled.go
+++ b/scheduled.go
@@ -51,7 +51,7 @@ func (s *scheduled) poll() {
 				queue, _ := message.Get("queue").String()
 				queue = strings.TrimPrefix(queue, Config.Namespace)
 				message.Set("enqueued_at", nowToSecondsWithNanoPrecision())
-				conn.Do("lpush", Config.Namespace+"queue:"+queue, message.ToJson())
+				conn.Do("lpush", queueKey(queue), message.ToJson())
 			}
 		}
 	}


### PR DESCRIPTION
This is a breaking change, but it only breaks compilation, not behavior, and it’s quite easy to adapt to, so I think it’s acceptable.