### PR TITLE
exit all worker/fetcher/manager correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.1
   - 1.4
+  - 1.5
 
 script:
   - go get github.com/customerio/gospec

--- a/fetcher.go
+++ b/fetcher.go
@@ -56,10 +56,9 @@ func (f *fetch) Fetch() {
 	f.processOldMessages()
 
 	go (func(c chan string) {
-	Lfetch:
 		for {
 			if f.Closed() {
-				break Lfetch
+				break
 			}
 
 			<-f.Ready()

--- a/fetcher.go
+++ b/fetcher.go
@@ -56,9 +56,10 @@ func (f *fetch) Fetch() {
 	f.processOldMessages()
 
 	go (func(c chan string) {
+	Lfetch:
 		for {
 			if f.Closed() {
-				break
+				break Lfetch
 			}
 
 			<-f.Ready()
@@ -82,6 +83,7 @@ func (f *fetch) Fetch() {
 		}
 	})(messages)
 
+Lmessage:
 	for {
 		select {
 		case message := <-messages:
@@ -89,7 +91,7 @@ func (f *fetch) Fetch() {
 		case <-f.stop:
 			f.closed = true
 			f.exit <- true
-			break
+			break Lmessage
 		}
 	}
 }

--- a/fetcher.go
+++ b/fetcher.go
@@ -23,7 +23,7 @@ type fetch struct {
 	messages chan *Msg
 	stop     chan bool
 	exit     chan bool
-	closed   bool
+	closed   chan bool
 }
 
 func NewFetch(queue string, messages chan *Msg, ready chan bool) Fetcher {
@@ -33,7 +33,7 @@ func NewFetch(queue string, messages chan *Msg, ready chan bool) Fetcher {
 		messages,
 		make(chan bool),
 		make(chan bool),
-		false,
+		make(chan bool),
 	}
 }
 
@@ -55,43 +55,49 @@ func (f *fetch) Fetch() {
 
 	f.processOldMessages()
 
-	go (func(c chan string) {
+	go func(c chan string) {
 		for {
+			// f.Close() has been called
 			if f.Closed() {
 				break
 			}
-
 			<-f.Ready()
-
-			(func() {
-				conn := Config.Pool.Get()
-				defer conn.Close()
-
-				message, err := redis.String(conn.Do("brpoplpush", f.queue, f.inprogressQueue(), 1))
-
-				if err != nil {
-					// If redis returns null, the queue is empty. Just ignore the error.
-					if err.Error() != "redigo: nil returned" {
-						Logger.Println("ERR: ", err)
-						time.Sleep(1 * time.Second)
-					}
-				} else {
-					c <- message
-				}
-			})()
+			f.tryFetchMessage(c)
 		}
-	})(messages)
+	}(messages)
 
-Lmessage:
+	f.handleMessages(messages)
+}
+
+func (f *fetch) handleMessages(messages chan string) {
 	for {
 		select {
 		case message := <-messages:
 			f.sendMessage(message)
 		case <-f.stop:
-			f.closed = true
-			f.exit <- true
-			break Lmessage
+			// Stop the redis-polling goroutine
+			close(f.closed)
+			// Signal to Close() that the fetcher has stopped
+			close(f.exit)
+			return
 		}
+	}
+}
+
+func (f *fetch) tryFetchMessage(messages chan string) {
+	conn := Config.Pool.Get()
+	defer conn.Close()
+
+	message, err := redis.String(conn.Do("brpoplpush", f.queue, f.inprogressQueue(), 1))
+
+	if err != nil {
+		// If redis returns null, the queue is empty. Just ignore the error.
+		if err.Error() != "redigo: nil returned" {
+			Logger.Println("ERR: ", err)
+			time.Sleep(1 * time.Second)
+		}
+	} else {
+		messages <- message
 	}
 }
 
@@ -126,7 +132,12 @@ func (f *fetch) Close() {
 }
 
 func (f *fetch) Closed() bool {
-	return f.closed
+	select {
+	case <-f.closed:
+		return true
+	default:
+		return false
+	}
 }
 
 func (f *fetch) inprogressMessages() []string {

--- a/manager.go
+++ b/manager.go
@@ -11,6 +11,7 @@ type manager struct {
 	job         jobFunc
 	concurrency int
 	workers     []*worker
+	workersM    *sync.Mutex
 	confirm     chan *Msg
 	stop        chan bool
 	exit        chan bool
@@ -33,9 +34,11 @@ func (m *manager) quit() {
 	Logger.Println("quitting queue", m.queueName(), "(waiting for", m.processing(), "/", len(m.workers), "workers).")
 	m.prepare()
 
+	m.workersM.Lock()
 	for _, worker := range m.workers {
 		worker.quit()
 	}
+	m.workersM.Unlock()
 
 	m.stop <- true
 	<-m.exit
@@ -63,18 +66,22 @@ Lmanage:
 }
 
 func (m *manager) loadWorkers() {
+	m.workersM.Lock()
 	for i := 0; i < m.concurrency; i++ {
 		m.workers[i] = newWorker(m)
 		m.workers[i].start()
 	}
+	m.workersM.Unlock()
 }
 
 func (m *manager) processing() (count int) {
+	m.workersM.Lock()
 	for _, worker := range m.workers {
 		if worker.processing() {
 			count++
 		}
 	}
+	m.workersM.Unlock()
 
 	return
 }
@@ -99,6 +106,7 @@ func newManager(queue string, job jobFunc, concurrency int, mids ...Action) *man
 		job,
 		concurrency,
 		make([]*worker, concurrency),
+		&sync.Mutex{},
 		make(chan *Msg),
 		make(chan bool),
 		make(chan bool),

--- a/manager.go
+++ b/manager.go
@@ -37,11 +37,9 @@ func (m *manager) quit() {
 		worker.quit()
 	}
 
-	Logger.Println("quitting queue", m.queueName(), " stoped all workers.")
 	m.stop <- true
 	<-m.exit
 
-	Logger.Println("quitting queue", m.queueName(), " before down.")
 	m.Done()
 }
 

--- a/manager.go
+++ b/manager.go
@@ -50,13 +50,14 @@ func (m *manager) manage() {
 
 	go m.fetch.Fetch()
 
+Lmanage:
 	for {
 		select {
 		case message := <-m.confirm:
 			m.fetch.Acknowledge(message)
 		case <-m.stop:
 			m.exit <- true
-			break
+			break Lmanage
 		}
 	}
 }

--- a/manager.go
+++ b/manager.go
@@ -50,14 +50,14 @@ func (m *manager) manage() {
 
 	go m.fetch.Fetch()
 
-Lmanager:
+Lmanage:
 	for {
 		select {
 		case message := <-m.confirm:
 			m.fetch.Acknowledge(message)
 		case <-m.stop:
 			m.exit <- true
-			break Lmanager
+			break Lmanage
 		}
 	}
 }

--- a/manager.go
+++ b/manager.go
@@ -37,9 +37,11 @@ func (m *manager) quit() {
 		worker.quit()
 	}
 
+	Logger.Println("quitting queue", m.queueName(), " stoped all workers.")
 	m.stop <- true
 	<-m.exit
 
+	Logger.Println("quitting queue", m.queueName(), " before down.")
 	m.Done()
 }
 

--- a/manager.go
+++ b/manager.go
@@ -50,14 +50,14 @@ func (m *manager) manage() {
 
 	go m.fetch.Fetch()
 
-Lmanage:
+Lmanager:
 	for {
 		select {
 		case message := <-m.confirm:
 			m.fetch.Acknowledge(message)
 		case <-m.stop:
 			m.exit <- true
-			break Lmanage
+			break Lmanager
 		}
 	}
 }

--- a/scheduled.go
+++ b/scheduled.go
@@ -9,15 +9,18 @@ import (
 
 type scheduled struct {
 	keys   []string
-	closed bool
+	closed chan bool
 	exit   chan bool
 }
 
 func (s *scheduled) start() {
 	go (func() {
 		for {
-			if s.closed {
+
+			select {
+			case <-s.closed:
 				return
+			default:
 			}
 
 			s.poll()
@@ -28,7 +31,7 @@ func (s *scheduled) start() {
 }
 
 func (s *scheduled) quit() {
-	s.closed = true
+	close(s.closed)
 }
 
 func (s *scheduled) poll() {
@@ -60,5 +63,5 @@ func (s *scheduled) poll() {
 }
 
 func newScheduled(keys ...string) *scheduled {
-	return &scheduled{keys, false, make(chan bool)}
+	return &scheduled{keys, make(chan bool), make(chan bool)}
 }

--- a/worker.go
+++ b/worker.go
@@ -22,7 +22,7 @@ func (w *worker) quit() {
 }
 
 func (w *worker) work(messages chan *Msg) {
-Lwork:
+Lworker:
 	for {
 		select {
 		case message := <-messages:
@@ -40,7 +40,7 @@ Lwork:
 			// ready to accept a message
 		case <-w.stop:
 			w.exit <- true
-			break Lwork
+			break Lworker
 		}
 	}
 

--- a/worker.go
+++ b/worker.go
@@ -22,6 +22,7 @@ func (w *worker) quit() {
 }
 
 func (w *worker) work(messages chan *Msg) {
+Lwork:
 	for {
 		select {
 		case message := <-messages:
@@ -39,9 +40,10 @@ func (w *worker) work(messages chan *Msg) {
 			// ready to accept a message
 		case <-w.stop:
 			w.exit <- true
-			return
+			break Lwork
 		}
 	}
+
 }
 
 func (w *worker) process(message *Msg) (acknowledge bool) {

--- a/worker.go
+++ b/worker.go
@@ -39,7 +39,7 @@ func (w *worker) work(messages chan *Msg) {
 			// ready to accept a message
 		case <-w.stop:
 			w.exit <- true
-			break
+			return
 		}
 	}
 }

--- a/worker.go
+++ b/worker.go
@@ -22,7 +22,7 @@ func (w *worker) quit() {
 }
 
 func (w *worker) work(messages chan *Msg) {
-Lworker:
+Lwork:
 	for {
 		select {
 		case message := <-messages:
@@ -40,7 +40,7 @@ Lworker:
 			// ready to accept a message
 		case <-w.stop:
 			w.exit <- true
-			break Lworker
+			break Lwork
 		}
 	}
 

--- a/workers.go
+++ b/workers.go
@@ -42,7 +42,7 @@ func Start() {
 func Quit() {
 	quitManagers()
 	schedule.quit()
-	waitForExit()
+	// waitForExit()
 }
 
 func StatsServer(port int) {

--- a/workers.go
+++ b/workers.go
@@ -42,6 +42,7 @@ func Start() {
 func Quit() {
 	quitManagers()
 	schedule.quit()
+	waitForExit()
 }
 
 func StatsServer(port int) {
@@ -67,8 +68,7 @@ func quitManagers() {
 }
 
 func waitForExit() {
-	for queue, manager := range managers {
+	for _, manager := range managers {
 		manager.Wait()
-		delete(managers, queue)
 	}
 }

--- a/workers.go
+++ b/workers.go
@@ -42,7 +42,6 @@ func Start() {
 func Quit() {
 	quitManagers()
 	schedule.quit()
-	// waitForExit()
 }
 
 func StatsServer(port int) {


### PR DESCRIPTION
I have a production environment based on go-workers. I used [runit](http://smarden.org/runit/) for daemon. While it run a few days,  I send "term" signal to stop it, but it can't stopped.

I check code of go-workers, and guess the bug is worker/fetcher/manager not exit correctly. 

About "for" "select" break:
test1: http://play.golang.org/p/l01ImEBCwv
test2: http://play.golang.org/p/pLQarqtZdg