### PR TITLE
Update the logging

### DIFF
--- a/middleware_logging.go
+++ b/middleware_logging.go
@@ -13,7 +13,7 @@ func (l *MiddlewareLogging) Call(queue string, message *Msg, next func() bool) (
 
 	start := time.Now()
 	Logger.Println(prefix, "start")
-	Logger.Println(prefix, "args: ", message.Args().ToJson())
+	Logger.Println(prefix, "args:", message.Args().ToJson())
 
 	defer func() {
 		if e := recover(); e != nil {


### PR DESCRIPTION
Removed trailing whitespace as Logger.Println already adds a whilespace between arguments and this makes reduces the spacing to a single space and not two spaces in the output.
