### PR TITLE
Add more informative stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ func main() {
   // Add a job to a queue
   workers.Enqueue("myqueue3", "Add", []int{1, 2})
 
+  // Add a job to a queue with retry
+  workers.EnqueueWithOptions("myqueue3", "Add", []int{1, 2}, workers.EnqueueOptions{Retry: true})
+  
   // stats will be available at http://localhost:8080/stats
   go workers.StatsServer(8080)
 


### PR DESCRIPTION
I'm add more informative stats like how much enqueued tasks in each queue and how much tasks in retry. Also i've add case description in readme.md with retry bcz for me it was not obvious i think that retry middleware work from the box without any additional params. I hope you find this pull request useful thank you.