### PR TITLE
make jobFunc public

### DIFF
--- a/job.go
+++ b/job.go
@@ -1,3 +1,3 @@
 package workers
 
-type jobFunc func(message *Msg)
+type JobFunc func(message *Msg)

--- a/manager.go
+++ b/manager.go
@@ -8,7 +8,7 @@ import (
 type manager struct {
 	queue       string
 	fetch       Fetcher
-	job         jobFunc
+	job         JobFunc
 	concurrency int
 	workers     []*worker
 	workersM    *sync.Mutex
@@ -93,7 +93,7 @@ func (m *manager) reset() {
 	m.fetch = Config.Fetch(m.queue)
 }
 
-func newManager(queue string, job jobFunc, concurrency int, mids ...Action) *manager {
+func newManager(queue string, job JobFunc, concurrency int, mids ...Action) *manager {
 	var customMids *Middlewares
 	if len(mids) == 0 {
 		customMids = Middleware

--- a/workers.go
+++ b/workers.go
@@ -28,7 +28,7 @@ var Middleware = NewMiddleware(
 	&MiddlewareStats{},
 )
 
-func Process(queue string, job jobFunc, concurrency int, mids ...Action) {
+func Process(queue string, job JobFunc, concurrency int, mids ...Action) {
 	access.Lock()
 	defer access.Unlock()
 


### PR DESCRIPTION
Since JobFunc is part of the function signature of public functions, it should also be public