### PR TITLE
Allow Config to be initialized without using Configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7
+  - 1.11.1
 
 script:
   - go get github.com/customerio/gospec

--- a/config.go
+++ b/config.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 type config struct {

--- a/config.go
+++ b/config.go
@@ -8,7 +8,7 @@ import (
 )
 
 type config struct {
-	processId    string
+	ProcessId    string
 	Namespace    string
 	PollInterval int
 	Pool         *redis.Pool
@@ -73,8 +73,10 @@ func Configure(options map[string]string) {
 				return err
 			},
 		},
-		func(queue string) Fetcher {
-			return NewFetch(queue, make(chan *Msg), make(chan bool))
-		},
+		DefaultFetch,
 	}
+}
+
+func DefaultFetch(queue string) Fetcher {
+	return NewFetch(queue, make(chan *Msg), make(chan bool))
 }

--- a/config_test.go
+++ b/config_test.go
@@ -31,14 +31,14 @@ func ConfigSpec(c gospec.Context) {
 	})
 
 	c.Specify("can specify custom process", func() {
-		c.Expect(Config.processId, Equals, "1")
+		c.Expect(Config.ProcessId, Equals, "1")
 
 		Configure(map[string]string{
 			"server":  "localhost:6379",
 			"process": "2",
 		})
 
-		c.Expect(Config.processId, Equals, "2")
+		c.Expect(Config.ProcessId, Equals, "2")
 	})
 
 	c.Specify("requires a server parameter", func() {

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/customerio/gospec"
 	. "github.com/customerio/gospec"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func EnqueueSpec(c gospec.Context) {

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -3,7 +3,7 @@ package workers
 import (
 	"github.com/customerio/gospec"
 	. "github.com/customerio/gospec"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func buildFetch(queue string) Fetcher {

--- a/fetcher.go
+++ b/fetcher.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 type Fetcher interface {

--- a/fetcher.go
+++ b/fetcher.go
@@ -152,5 +152,5 @@ func (f *fetch) inprogressMessages() []string {
 }
 
 func (f *fetch) inprogressQueue() string {
-	return fmt.Sprint(f.queue, ":", Config.processId, ":inprogress")
+	return fmt.Sprint(f.queue, ":", Config.ProcessId, ":inprogress")
 }

--- a/manager_test.go
+++ b/manager_test.go
@@ -1,13 +1,14 @@
 package workers
 
 import (
-	"fmt"
+	"reflect"
+	"runtime"
 	"sync"
 	"time"
 
 	"github.com/customerio/gospec"
 	. "github.com/customerio/gospec"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 type customMid struct {
@@ -54,7 +55,9 @@ func ManagerSpec(c gospec.Context) {
 
 		c.Specify("sets job function", func() {
 			manager := newManager("myqueue", testJob, 10)
-			c.Expect(fmt.Sprint(manager.job), Equals, fmt.Sprint(testJob))
+			expected := runtime.FuncForPC(reflect.ValueOf(manager.job).Pointer()).Name()
+			actual := runtime.FuncForPC(reflect.ValueOf(testJob).Pointer()).Name()
+			c.Expect(expected, Equals, actual)
 		})
 
 		c.Specify("sets worker concurrency", func() {

--- a/middleware_retry_test.go
+++ b/middleware_retry_test.go
@@ -3,7 +3,7 @@ package workers
 import (
 	"github.com/customerio/gospec"
 	. "github.com/customerio/gospec"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"time"
 )
 

--- a/middleware_stats_test.go
+++ b/middleware_stats_test.go
@@ -3,7 +3,7 @@ package workers
 import (
 	"github.com/customerio/gospec"
 	. "github.com/customerio/gospec"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"time"
 )
 

--- a/scheduled.go
+++ b/scheduled.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 type scheduled struct {

--- a/scheduled_test.go
+++ b/scheduled_test.go
@@ -3,7 +3,7 @@ package workers
 import (
 	"github.com/customerio/gospec"
 	. "github.com/customerio/gospec"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func ScheduledSpec(c gospec.Context) {


### PR DESCRIPTION
For example so that we can use Redis over a TLS connection, and that configuration requires more than just strings in a map.

This PR also updates `github.com/garyburd/redigo/redis` to `github.com/gomodule/redigo/redis`, and fixes the ManagerSpec so that it passes on go1.11.1.